### PR TITLE
docs: fix vulnerability scan example

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -46,7 +46,7 @@ git pkgs show abc123                      # changes in a single commit
 Check dependencies against the OSV database for known CVEs:
 
 ```bash
-git pkgs vulns              # scan current dependencies
+git pkgs vulns scan         # scan current dependencies
 git pkgs vulns blame        # who introduced each vulnerability
 git pkgs vulns praise       # who fixed vulnerabilities
 ```


### PR DESCRIPTION
## Summary

- Correct the Getting Started vulnerability scan command to use `git pkgs vulns scan`.
- Align the example with the actual CLI subcommand.

Closes git-pkgs/git-pkgs#275

## Verification

- `hugo --minify`